### PR TITLE
Add showdown to dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,3 +1,7 @@
 {
-  "main": "md"
+  "main": "md",
+  "registry": "jspm",
+  "dependencies": {
+    "showdown": "^0.3.1"
+  }
 }


### PR DESCRIPTION
This allows to use `md` plugin right after `install` command.

Why it was not included from the start? Could it be, that showdown was exluded to optimize imports? 
